### PR TITLE
loosen constraint on template haskell version

### DIFF
--- a/qq-literals.cabal
+++ b/qq-literals.cabal
@@ -16,7 +16,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     QQLiterals
   build-depends:       base >= 4.7 && < 5,
-                       template-haskell == 2.10.*
+                       template-haskell >= 2.10.0
   default-language:    Haskell2010
 
 test-suite qq-literals-test


### PR DESCRIPTION
This might not be the right change - perhaps you want to put an upper bound of 2.12.0.0 in?