### PR TITLE
include error case

### DIFF
--- a/qq-literals.cabal
+++ b/qq-literals.cabal
@@ -18,6 +18,7 @@ library
   build-depends:       base >= 4.7 && < 5,
                        template-haskell >= 2.10.0
   default-language:    Haskell2010
+  ghc-options:         -Werror -Wall -Wincomplete-patterns
 
 test-suite qq-literals-test
   type:                exitcode-stdio-1.0
@@ -28,7 +29,7 @@ test-suite qq-literals-test
                        qq-literals,
                        template-haskell,
                        network-uri
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Werror -Wall -Wincomplete-patterns
   default-language:    Haskell2010
 
 source-repository head

--- a/qq-literals.cabal
+++ b/qq-literals.cabal
@@ -18,6 +18,8 @@ library
   build-depends:       base >= 4.7 && < 5,
                        template-haskell >= 2.10.0
   default-language:    Haskell2010
+  ghc-options:         -Wall -Wincomplete-patterns
+
 
 test-suite qq-literals-test
   type:                exitcode-stdio-1.0
@@ -28,7 +30,7 @@ test-suite qq-literals-test
                        qq-literals,
                        template-haskell,
                        network-uri
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-patterns
   default-language:    Haskell2010
 
 source-repository head

--- a/qq-literals.cabal
+++ b/qq-literals.cabal
@@ -18,7 +18,6 @@ library
   build-depends:       base >= 4.7 && < 5,
                        template-haskell >= 2.10.0
   default-language:    Haskell2010
-  ghc-options:         -Werror -Wall -Wincomplete-patterns
 
 test-suite qq-literals-test
   type:                exitcode-stdio-1.0
@@ -29,7 +28,7 @@ test-suite qq-literals-test
                        qq-literals,
                        template-haskell,
                        network-uri
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Werror -Wall -Wincomplete-patterns
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
 source-repository head

--- a/src/QQLiterals.hs
+++ b/src/QQLiterals.hs
@@ -10,7 +10,7 @@ qqLiteral parse parseFn = QuasiQuoter {..}
   where
   quoteExp str =
     case parse str of
-      Right _ -> [| case $(varE parseFn) str of { Right x -> x } |]
+      Right _ -> [| case $(varE parseFn) str of { Right x -> x; Left x -> error ("can't happen: " ++ show x)} |]
       Left err -> fail err
 
   quotePat  = unsupported "pattern"


### PR DESCRIPTION
When you compile with -Wall -Werror, the current version fails spuriously. This PR adds an error case: while it's _possible_ to misuse this by passing a different Name to qqLiteral than the function that's being called, it's a very weird corner case, and doesn't seem worth failing warnings for.